### PR TITLE
Get API to list all supported libraries based on app type

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -1,6 +1,8 @@
 package consts
 
 const (
+	//TemplatePath the root folder for templates
+	TemplatePath       = "/template"
 	//CliTempatePath path for cli templates
 	CliTempatePath     = "/template/cli"
 	REST_TEMPLATE_PATH = "/template/rest"

--- a/server/routes.go
+++ b/server/routes.go
@@ -14,6 +14,8 @@ func (ws *WebServer) RegisterRoute() {
 	ws.server.POST("/exploreapp", handle.GenerateGitHubRepo)
 	ws.server.GET("/liveness", handle.Liveness)
 	ws.server.POST("/test", handle.Test)
+	ws.server.GET("/libs", handle.GetSupportedLibraries)
+
 	// Get user value
 	//ws.server.GET("/user/:name", handle.GetUserValue)
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -88,6 +88,11 @@ func GetWorkingDirNoError() string {
 	return path
 }
 
+//GetTemplateDir get root template directory
+func GetTemplateDir() string {
+	return filepath.Join(GetWorkingDirNoError(), consts.TemplatePath)
+}
+
 //AddCliLibs add these libs to supported cli libs
 func AddCliLibs(cliNames []string) {
 	consts.SupportedCliLib = cliNames


### PR DESCRIPTION
Implementation of the GET API endpoint to fetch a list of folders between template and codebase based on an apptype parameter

Usage example:
GET /libs?apptype=cli